### PR TITLE
Enable CI on multiple OS and Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        # when changing version, also change setup.py
         python-version: ['3.8', '3.9']
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         # when changing version, also change setup.py
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8']
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
         python-version: ['3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
-
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
@@ -38,11 +37,15 @@ jobs:
         pip install pyvinecopulib
         pytest tests/
 
+  gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     # Install all dev dependencies to build notebooks etc.
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.8
         activate-environment: synthia
         environment-file: environment.yml
 
@@ -57,7 +60,7 @@ jobs:
       run: sphinx-build -v -b html docs/ docs/_build
 
     - name: Publish docs
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,26 @@ on: [push, pull_request]
 
 jobs:
   main:
-    runs-on: ubuntu-latest
-
+    name: ${{ matrix.os }} with python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ['3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
-    
-    - uses: goanpeca/setup-miniconda@v1
+
+    - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
         activate-environment: synthia-test
         environment-file: environment-test.yml
 
     - name: Install Synthia (test env)
       # 'shell' required to activate environment.
-      # See https://github.com/goanpeca/setup-miniconda#important.
+      # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: pip install .
 
@@ -32,14 +39,16 @@ jobs:
         pytest tests/
 
     # Install all dev dependencies to build notebooks etc.
-    - uses: goanpeca/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
         activate-environment: synthia
         environment-file: environment.yml
 
     - name: Install Synthia (dev env)
       # 'shell' required to activate environment.
-      # See https://github.com/goanpeca/setup-miniconda#important.
+      # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: pip install .
 
@@ -48,7 +57,7 @@ jobs:
       run: sphinx-build -v -b html docs/ docs/_build
 
     - name: Publish docs
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -1,6 +1,3 @@
 name: synthia-test
-channels:
-  - defaults
 dependencies:
-  - python=3.8 # when changing this, also change setup.py
   - pytest

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -1,3 +1,5 @@
 name: synthia-test
+channels:
+  - defaults
 dependencies:
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,7 @@
 name: synthia
+channels:
+  - defaults
+  - conda-forge
 dependencies:
   - pytest
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,5 @@
 name: synthia
-channels:
-  - defaults
-  - conda-forge
 dependencies:
-  - python=3.8
   - pytest
   - numpy
   - scipy

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     packages=find_packages(),
-    python_requires=">=3.8", # when changing this, also change environment-test.yml
+    python_requires=">=3.8", # when changing this, also change ci.yml
     install_requires=[
         "numpy",
         "scipy",


### PR DESCRIPTION
For latest Ubuntu, macOS and Windows and Python 3.8 for now until next pyvinecopulib release.